### PR TITLE
Close italics scope

### DIFF
--- a/consoleApp/Writer/WordWriter.cs
+++ b/consoleApp/Writer/WordWriter.cs
@@ -86,12 +86,12 @@ namespace STAR.Writer
                     italicsLevel--;
                     break;
                 case Command.Type.NewSection:
-                    if (italicsLevel != 0) //close italics scope to avoid spilling italics over the next sections
-                        writer.WriteLine(EndItalics);
+                    if (italicsLevel != 0)
+                        while (italicsLevel-- > 0)//close italics scope to avoid spilling italics over the next sections
+                            writer.WriteLine(EndItalics);
                     writer.WriteLine();
                     writer.WriteLine(pageBreak);
                     writer.WriteLine();
-                    italicsLevel = 0;
                     break;
             }
         }

--- a/consoleApp/Writer/WordWriter.cs
+++ b/consoleApp/Writer/WordWriter.cs
@@ -86,9 +86,8 @@ namespace STAR.Writer
                     italicsLevel--;
                     break;
                 case Command.Type.NewSection:
-                    if (italicsLevel != 0)
-                        while (italicsLevel-- > 0)//close italics scope to avoid spilling italics over the next sections
-                            writer.WriteLine(EndItalics);
+                    while (italicsLevel-- > 0)//close italics scope to avoid spilling italics over the next sections
+                        writer.WriteLine(EndItalics);
                     writer.WriteLine();
                     writer.WriteLine(pageBreak);
                     writer.WriteLine();

--- a/consoleApp/Writer/WordWriter.cs
+++ b/consoleApp/Writer/WordWriter.cs
@@ -53,8 +53,10 @@ namespace STAR.Writer
             WriteHeader(m_Title, writer);
             writer.WriteLine();
 
+            int italicsLevel = 0;
+
             foreach (Command command in commands)
-                WriteCommand(writer, command);
+                WriteCommand(writer, command, ref italicsLevel);
 
             writer.Write(footer);
         }
@@ -65,7 +67,7 @@ namespace STAR.Writer
             writer.Write(headerFormatted);
         }
 
-        static void WriteCommand(TextWriter writer, in Command command)
+        static void WriteCommand(TextWriter writer, in Command command, ref int italicsLevel)
         {
             switch (command.type)
             {
@@ -77,14 +79,19 @@ namespace STAR.Writer
                     break;
                 case Command.Type.ItalicsBegin:
                     writer.Write(BeginItalics);
+                    italicsLevel++;
                     break;
                 case Command.Type.ItalicsEnd:
                     writer.Write(EndItalics);
+                    italicsLevel--;
                     break;
                 case Command.Type.NewSection:
+                    if (italicsLevel != 0) //close italics scope to avoid spilling italics over the next sections
+                        writer.WriteLine(EndItalics);
                     writer.WriteLine();
                     writer.WriteLine(pageBreak);
                     writer.WriteLine();
+                    italicsLevel = 0;
                     break;
             }
         }


### PR DESCRIPTION
- Prevent italics formatting from spilling from one section to another.